### PR TITLE
add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   "devDependencies": {},
   "dependencies": {
     "leaflet": "^0.7.3",
-    "pouchdb": "^3.3.1"
+    "pouchdb": "^5.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,10 @@
   "bugs": {
     "url": "https://github.com/MazeMap/Leaflet.TileLayer.PouchDBCached/issues"
   },
-  "homepage": "https://github.com/MazeMap/Leaflet.TileLayer.PouchDBCached#readme"
+  "homepage": "https://github.com/MazeMap/Leaflet.TileLayer.PouchDBCached#readme",
+  "devDependencies": {},
+  "dependencies": {
+    "leaflet": "^0.7.3",
+    "pouchdb": "^3.3.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "leaflet.tilelayer.pouchdbcached",
+  "version": "0.2.0",
+  "description": "Allows all TileLayers to cache into PouchDB for offline use",
+  "main": "L.TileLayer.PouchDBCached.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MazeMap/Leaflet.TileLayer.PouchDBCached.git"
+  },
+  "keywords": [
+    "leaflet",
+    "pouchdb"
+  ],
+  "author": "Iván Sánchez Ortega <ivan@mazemap.no>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/MazeMap/Leaflet.TileLayer.PouchDBCached/issues"
+  },
+  "homepage": "https://github.com/MazeMap/Leaflet.TileLayer.PouchDBCached#readme"
+}


### PR DESCRIPTION
allows installation via npm. Even if you don't register it at npmjs.org, users can install from github using:

``` bash
npm install MazeMap/Leaflet.TileLayer.PouchDBCached
```
