### PR TITLE
Add "cacheURLMask" option to mask DB id for access tokens and such.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@ Options available are as follows:
 * `saveToCache`: Whether to save new tiles to the cache or not. Defaults to true.
 * `useOnlyCache`: Whether to fetch tiles from the network or not. Defaults to false.
 * `cacheMaxAge`: Time, in milliseconds, for any given tile to be considered 'fresh'. Tiles older than this value will be re-requested from the network. Defaults to 24 hours.
+* `cacheURLMask`: A regular expresstion to mask the URL so that access tokens and the sort won't cause cache misses. (e.g. /access_token=[^&]*/)
 
 New functions available are as follows:
 * `seed`: Starts seeding the cache for a given bounding box (a `L.LatLngBounds`), and between the two given zoom levels.


### PR DESCRIPTION
I have added the option "cacheURLMask" to allow the user to add a mask for the URL that is used as the database id.  This will allow the user to mask out things like the access_token and anything else that might be causing cache misses for no practical reason.